### PR TITLE
resolves #3 : add support for core datastore handling to the framework

### DIFF
--- a/kore-data/pom.xml
+++ b/kore-data/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+	  <groupId>kanad</groupId>
+	  <artifactId>kanad-parent-pom</artifactId>
+	  <version>1.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>kore-data</artifactId>
+  <packaging>jar</packaging>
+  
+  <name>kore-data</name>
+  <url>http://maven.apache.org</url>
+  
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-api</artifactId>
+	</dependency>
+	<dependency>
+    	<groupId>org.apache.logging.log4j</groupId>
+    	<artifactId>log4j-core</artifactId>
+  	</dependency>
+
+	<dependency>
+		<groupId>mysql</groupId>
+		<artifactId>mysql-connector-java</artifactId>
+		<version>5.1.41</version>
+	</dependency>
+	<dependency>
+		<groupId>org.hibernate</groupId>
+		<artifactId>hibernate-entitymanager</artifactId>
+		<version>5.2.1.Final</version>
+	</dependency>
+	<dependency>
+		<groupId>org.hibernate</groupId>
+		<artifactId>hibernate-validator</artifactId>
+		<version>5.2.0.Final</version>
+	</dependency>
+    <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-spatial</artifactId>
+        <version>5.2.12.Final</version>
+    </dependency>
+	<!-- for c3p0 DB connection pooling -->
+	<dependency>
+    	<groupId>org.hibernate</groupId>
+    	<artifactId>hibernate-c3p0</artifactId>
+    	<version>5.2.1.Final</version>
+	</dependency>
+	<dependency>
+    	<groupId>com.mchange</groupId>
+    	<artifactId>c3p0</artifactId>
+    	<version>0.9.5.2</version>
+	</dependency>
+  </dependencies>
+	
+ <build>
+  	<plugins>
+  		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+      	</plugin>
+     </plugins>
+ </build>
+  	
+</project>

--- a/kore-data/src/main/java/kanad/kore/data/dao/Dao.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/Dao.java
@@ -1,0 +1,26 @@
+package kanad.kore.data.dao;
+
+/**
+ * @param <T> can be either javax.persistence.EntityManager or java.sql.Connection.
+ * Based on this, the Dao will be either Jpa based i.e. JpaDao or JDBC based raw one i.e. RawDao.
+ * There are corresponding parameterized DAO providers that return the respective Dao variants. 
+ */
+public interface Dao<T> {
+	void set(T connOrEntMgr);
+	
+	T get();
+	
+	void close();
+	
+	void beginTransaction();
+	
+	void commitTransaction();
+	
+	void rollbackTransaction();
+	
+	boolean hasActiveTransaction();
+	
+	public void setAutoCommit(boolean autoCommit);
+	
+	public boolean isAutoCommit();
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/DaoProvider.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/DaoProvider.java
@@ -1,0 +1,80 @@
+package kanad.kore.data.dao;
+
+import kanad.kore.data.dao.DaoProviderFactory.DaoImplementationStrategy;
+
+public interface DaoProvider<DAO, T> {
+	/**
+	 * 
+	 * @param daoClassname the name of the DAO class
+	 * @return the DAO instance for the corresponding class.
+	 * The implementation shall provide the DAO instance with a new instance of EntityManager or JDBC connection.
+	 */
+	DAO getDAO(String daoClassname);
+	
+	
+	/**
+	 * 
+	 * @param daoClassname. Please make sure you provide the fully qualified classname if the base package name
+	 * is not set on the underlying DAO provider implementation; otherwise a simple classname suffices.
+	 * @param existingDAO
+	 * @return  the DAO instance for the corresponding class constructed using the
+	 * an existing instance of underlying DB machanism present in existing DAO.
+	 * 
+	 * Use this variant when you want to provide an existing instance of underlying
+	 * DB machanism (e.g. EntityManager in case of JpaDao or JDBC Connection in case of RawDao) 
+	 * to the new DAO. You may typically need this kind of scenario in case of transactions that
+	 * span across multiple DAOs. Use this version only if necessary, default one will suffice
+	 * for most of the purposes.
+	 */
+	DAO getDAO(String daoClassname, DAO existingDAO);
+
+	/**
+	 * 
+	 * @param daoClassname the name of the DAO class
+	 * @param parameterizedClass the class name of the parameterized type required by the corresponding DAO class.
+	 * @return
+	 */
+	DAO getDAO(String daoClassname, Class<? extends T> parameterizedClass);
+	
+	
+	/**
+	 * 
+	 * @param daoClass the DAO class
+	 * @return the DAO instance for the corresponding class.
+	 * The implementation shall provide the DAO instance with a new instance of EntityManager or JDBC connection.
+	 */
+	DAO getDAO(Class<? extends DAO> daoClass);
+
+	/**
+	 * 
+	 * @param daoClass
+	 * @param existingDAO
+	 * @return refer getDAO(String daoClassname, DAO existingDAO)
+	 */
+	DAO getDAO(Class<? extends DAO> daoClass, DAO existingDAO);
+
+	/**
+	 * 
+	 * @param daoClass the DAO class
+	 * @param parameterizedClass the class of the parameterized type required by the corresponding DAO class.
+	 * @return
+	 */
+	DAO getDAO(Class<? extends DAO> daoClass, Class<? extends T> parameterizedClass);
+	
+	
+	/**
+	 * Optional
+	 * @return the base package where all the DAOs are implemented. 
+	 * This method will return non null package name only when the underlying provider implementation allows to
+	 * configure one. When this value is set, getDAO() method will try to locate the DAO implementation class identified
+	 * by fully qualified classname: packageName.classname and return it's instance.
+	 *
+	 * This is just a convenient way to avoid passing fully qualified DAO implementation classname when all DAO
+	 * classes are located in a single base package; otherwise one shall pass the fully qualified classname.
+	 */
+	String getPackageName();
+	
+	DaoImplementationStrategy getImplementationStrategy();
+	
+	void close();
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/DaoProviderFactory.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/DaoProviderFactory.java
@@ -1,0 +1,126 @@
+package kanad.kore.data.dao;
+
+import kanad.kore.data.dao.jpa.JpaDaoProvider;
+import kanad.kore.data.dao.jpa.JpaDaoProviderImpl;
+import kanad.kore.data.dao.raw.RawDaoProvider;
+import kanad.kore.data.dao.raw.RawDaoProviderImpl;
+
+import java.util.Properties;
+
+public class DaoProviderFactory {
+	public enum DaoImplementationStrategy{
+		/**
+		 * With per instance strategy, there is one distinct Connection or EntityManager instance 
+		 * per DAO instance.
+		 * For multi DAO scoped transactions, the same underlying Connection or EntityManager needs to be shared amongst
+		 * multiple DAOs. In such a case, make sure you use getDAO(String classname, DAO existingDAO) method of
+		 * DaoProvider which propagates the same instance of underlying Connection or EntityManager across all the DAOs
+		 * involved in a transaction.
+		 * Default is PER_INSTANCE.
+		 */
+		PER_INSTANCE,
+		/**
+		 * With per thread strategy, there is one distinct Connection or EntityManager instance 
+		 * for all the DAOs instances in the scope of a single thread.
+		 * This sort of strategy is generally used in places like requests made to web app or RESTful APIs,
+		 * where the Connection or EntityManager instance is REQUEST scoped.
+		 */
+		PER_THREAD,
+	}
+
+	/**
+	 * 
+	 * @param persistentUnit
+	 * @return an implementation of JpaDaoProvider
+	 * This type of DAO provider shall be used with JpaDao where the data access is done using
+	 * the JPA and the corresponding EntityManager/EntityManagerFactory.
+	 */
+	public static JpaDaoProvider create(String persistentUnit){
+		return new JpaDaoProviderImpl(persistentUnit, null);
+	}
+	
+	/**
+	 * 
+	 * @param persistentUnit
+	 * @param strategy
+	 * @return an implementation of JpaDaoProvider
+	 * This type of DAO provider shall be used with JpaDao where the data access is done using
+	 * the JPA and the corresponding EntityManager/ EntityManagerFactory.
+	 */
+	public static JpaDaoProvider create(String persistentUnit, DaoImplementationStrategy strategy){
+		return new JpaDaoProviderImpl(persistentUnit, null, strategy);
+	}
+	
+	/**
+	 * 
+	 * @param persistentUnit
+	 * @param daoPackageName
+	 * @return an implementation of JpaDaoProvider
+	 * This type of DAO provider shall be used with JpaDao where the
+	 * data access is done using the JPA and the corresponding EntityManager/
+	 * EntityManagerFactory.
+	 */
+	public static JpaDaoProvider create(String persistentUnit, String daoPackageName){
+		return new JpaDaoProviderImpl(persistentUnit, daoPackageName);
+	}
+	
+	/**
+	 * 
+	 * @param persistentUnit
+	 * @param daoPackageName
+	 * @param strategy the strategy to be used by implementation for managing underlying EntityManager.
+	 * @return an implementation of JpaDaoProvider
+	 * This type of DAO provider shall be used with JpaDao where the data access is done using
+	 * the JPA and the corresponding EntityManager/EntityManagerFactory.
+	 */
+	public static JpaDaoProvider create(String persistentUnit, String daoPackageName,
+										DaoImplementationStrategy strategy){
+		return new JpaDaoProviderImpl(persistentUnit, daoPackageName, strategy);
+	}
+
+	/**
+	 * @return an implementation of RawDaoProvider
+	 * This type of DAO provider shall be used with RawDao where the
+	 * data access is done directly over the native JDBC connection.
+	 */
+	public static RawDaoProvider create(Properties connProperties){
+		return new RawDaoProviderImpl(null, connProperties);
+	}
+	
+	/**
+	 * 
+	 * @param connProperties
+	 * @param strategy
+	 * @return an implementation of RawDaoProvider
+	 * This type of DAO provider shall be used with RawDao where the
+	 * data access is done directly over the native JDBC connection.
+	 * 
+	 */
+	public static RawDaoProvider create(Properties connProperties, DaoImplementationStrategy strategy){
+		return new RawDaoProviderImpl(null, connProperties, strategy);
+	}
+	
+	/**
+	 * 
+	 * @param daoPackageName
+	 * @return an implementation of RawDaoProvider
+	 * This type of DAO provider shall be used with RawDao where the
+	 * data access is done directly over the native JDBC connection.
+	 */
+	public static RawDaoProvider create(String daoPackageName, Properties connProperties){
+		return new RawDaoProviderImpl(daoPackageName, connProperties);
+	}
+
+	/**
+	 * 
+	 * @param daoPackageName
+	 * @return an implementation of RawDaoProvider
+	 * @param strategy the strategy to be used by implementation for managing underlying Connection.
+	 * This type of DAO provider shall be used with RawDao where the
+	 * data access is done directly over the native JDBC connection.
+	 */
+	public static RawDaoProvider create(String daoPackageName, Properties connProperties,
+										DaoImplementationStrategy strategy){
+		return new RawDaoProviderImpl(daoPackageName, connProperties, strategy);
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/PerThreadManagedContext.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/PerThreadManagedContext.java
@@ -1,0 +1,45 @@
+package kanad.kore.data.dao;
+
+import javax.persistence.EntityManager;
+
+/**
+ * This class captures the per thread managed context/storage when DAO framework is setup/used in PER_THREAD mode.
+ * The respective DaoProvider implementation (be it Raw one or JPA based), shall hold and provide a distinct instance of this class per thread.
+ * Typically this is achieved by using ThreadLocal storage. The current DaoProvider implementations use this design while implementing PER_THREAD
+ * strategy. 
+ * One shall note that the DAO consumer or client code must make sure that every call to get a new DAO is matched by a corresponding call to
+ * DAO.close(). In the end, number of get new DAO calls shall match number of DAO.close() calls; otherwise the DaoProvider implementation is
+ * vulnerable to Connection Leaks.  
+ */
+public class PerThreadManagedContext {
+	private EntityManager entityManager;
+	private int entityManagerCount = 0;
+	
+	/**
+	 * @return the entityManager
+	 */
+	public EntityManager getEntityManager() {
+		return entityManager;
+	}
+	
+	/**
+	 * @param entityManager the entityManager to set
+	 */
+	public void setEntityManager(EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+	
+	/**
+	 * @return the entityManagerCount
+	 */
+	public int getEntityManagerCount() {
+		return entityManagerCount;
+	}
+	
+	/**
+	 * @param entityManagerCount the entityManagerCount to set
+	 */
+	public void setEntityManagerCount(int entityManagerCount) {
+		this.entityManagerCount = entityManagerCount;
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/AbstractJpaDao.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/AbstractJpaDao.java
@@ -1,0 +1,93 @@
+package kanad.kore.data.dao.jpa;
+
+import kanad.kore.data.dao.DaoProviderFactory.DaoImplementationStrategy;
+import kanad.kore.data.entity.jpa.KEntity;
+import org.apache.logging.log4j.LogManager;
+
+import javax.persistence.EntityManager;
+import java.lang.ref.WeakReference;
+
+public abstract class AbstractJpaDao implements JpaDao {
+	protected EntityManager entityManager;
+	private WeakReference<JpaDaoProviderImpl> providerRef;
+	
+	public AbstractJpaDao(){
+	}
+	
+	
+	protected void setJpaDaoProvider(JpaDaoProviderImpl jpaDaoProviderImpl){
+		providerRef = new WeakReference<JpaDaoProviderImpl>(jpaDaoProviderImpl);
+	}
+	
+	public void close() {
+		LogManager.getLogger().info("Closing entity manager...");
+		if(providerRef.get().getImplementationStrategy() == DaoImplementationStrategy.PER_THREAD){
+			providerRef.get().closeThreadLocalManagedEntityManager();
+		}else if(entityManager != null && entityManager.isOpen()){
+			entityManager.close();
+		}
+	}
+	
+	public void beginTransaction() {
+		entityManager.getTransaction().begin();
+		LogManager.getLogger().info("Transaction started");
+	}
+	
+	public void commitTransaction() {
+		entityManager.getTransaction().commit();
+		LogManager.getLogger().info("Transaction committed");
+	}
+	
+	public void rollbackTransaction() {
+		LogManager.getLogger().info("Rolling back transaction");
+		entityManager.getTransaction().rollback();
+	}
+	
+	public boolean hasActiveTransaction() {
+		return entityManager.getTransaction().isActive();
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#set(java.lang.Object)
+	 */
+	@Override
+	public void set(EntityManager em) {
+		entityManager = em;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#get()
+	 */
+	@Override
+	public EntityManager get() {
+		return entityManager;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#setAutoCommit(boolean)
+	 */
+	@Override
+	public void setAutoCommit(boolean autoCommit) {
+		//Doesn't make sense for JPA based DAOs.
+		throw new UnsupportedOperationException();
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#isAutoCommit()
+	 */
+	@Override
+	public boolean isAutoCommit() {
+		return false;//always
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.jpa.JpaDao#refresh(java.lang.Object)
+	 */
+	@Override
+	//One more option and which seems better one is to have cascade refresh rather than calling refresh
+	//on each embedded entity field on the given entity.
+	//Refer: http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#pc-cascade-refresh
+	public void refresh(KEntity entity) {
+		entityManager.refresh(entity);
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/DefaultJpaDao.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/DefaultJpaDao.java
@@ -1,0 +1,91 @@
+package kanad.kore.data.dao.jpa;
+
+import kanad.kore.data.entity.jpa.AbstractEntity;
+import kanad.kore.data.entity.jpa.Remark;
+
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * This JPA DAO is a generic one i.e. - interface lays down the contract for all the data access operations that are
+ * commonly expected while building any CRUD application. All the concrete, purpose specific DAOs in the given
+ * application will either implement this interface or extend from a class which provides the implementation of this
+ * interface.
+ * 
+ * Let's say- there's an application for trip management module/microservice, then:
+ * - all Trip Management concrete DAOs will either implement this interface or
+ * - extend from a class, say - TripMgmtJpaDao which provides an implementation of this interface.
+ */
+public interface DefaultJpaDao<T> {
+	//TODO: Dont make  getById and getBySecureId parameterized; instead have them return AbstractEntity and
+	// keep rest of the methods parameterized.
+	
+	/**
+	 * 
+	 * @param id of the entity in the underlying DB.
+	 * @return returns an entity matching the given id. 
+	 */
+	public AbstractEntity getById(long id);
+	
+	/**
+	 * 
+	 * @param secureId
+	 * @return returns an entity matching the given secureID.
+	 */
+	public AbstractEntity getBySecureId(String secureId);
+	
+	/**
+	 * 
+	 * @param entity to be persisted/added into DB.
+	 */
+	public void add(T entity);
+	
+	/**
+	 * 
+	 * @param entities the collection containing all the entities to be persisted.
+	 */
+	public void addAll(Collection<T> entities);
+	
+	/**
+	 * 
+	 * @param entity to be updated and merged with the underlying entity in the DB.
+	 * @return merged entity post updation.
+	 */
+	public T update(T entity);
+	
+	/**
+	 * 
+	 * @param entity entity to be soft deleted.
+	 */
+	public void delete(T entity);
+	
+	
+	/**
+	 * 
+	 * @param entity entity to be hard deleted.
+	 */
+	public void deleteHard(T entity);
+	
+	
+	/**
+	 * Delete all the entities of <T> from DB.
+	 */
+	public void deleteAll(boolean hardDelete);
+	
+	/**
+	 * 
+	 * @param orgId 
+	 * @return all the entities (obviously concrete subclass instances) corresponding to a given org id.
+	 * The concrete subclasses shall override this method and return all entities pertaining to a concrete subclasses.
+	 */	
+	public List<T> getAll(int orgId);
+	
+	
+	/**
+	 * 
+	 * @param remark the remark to persist to the DB.
+	 * Use this method only when adding new remark on an existing entity which is being updated/merged.
+	 */
+	public void addRemark(Remark remark);
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/JpaDao.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/JpaDao.java
@@ -1,0 +1,15 @@
+package kanad.kore.data.dao.jpa;
+
+import kanad.kore.data.dao.Dao;
+import kanad.kore.data.entity.jpa.KEntity;
+
+import javax.persistence.EntityManager;
+
+public interface JpaDao extends Dao<EntityManager> {
+	/**
+	 * 
+	 * @param entity in the current persistent context, the state of which needs to be refreshed/reconciled from DB.
+	 * Refreshes the state of the entity instance in the current persistent context from the database.
+	 */
+	void refresh(KEntity entity);
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/JpaDaoProvider.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/JpaDaoProvider.java
@@ -1,0 +1,8 @@
+package kanad.kore.data.dao.jpa;
+
+import kanad.kore.data.dao.DaoProvider;
+import kanad.kore.data.entity.jpa.KEntity;
+
+public interface JpaDaoProvider extends DaoProvider<JpaDao, KEntity> {
+
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/JpaDaoProviderImpl.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/JpaDaoProviderImpl.java
@@ -1,0 +1,284 @@
+package kanad.kore.data.dao.jpa;
+
+import kanad.kore.data.dao.DaoProviderFactory.DaoImplementationStrategy;
+import kanad.kore.data.dao.PerThreadManagedContext;
+import kanad.kore.data.entity.jpa.KEntity;
+import org.apache.logging.log4j.LogManager;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class JpaDaoProviderImpl implements JpaDaoProvider {
+	private EntityManagerFactory emf;
+	//DAO base package name
+	private String packageName;
+	private DaoImplementationStrategy strategy;
+	private ThreadLocal<PerThreadManagedContext> threadLocalManagedContext = new ThreadLocal<>();
+	
+	public JpaDaoProviderImpl(String persistentUnit, String packageName){
+		this(persistentUnit, packageName, DaoImplementationStrategy.PER_INSTANCE);
+	}
+	
+	public JpaDaoProviderImpl(String persistentUnit, String packageName, DaoImplementationStrategy strategy){
+		emf = Persistence.createEntityManagerFactory(persistentUnit);
+		this.packageName = packageName;
+		this.strategy = strategy;
+	}
+	
+	
+	public DaoImplementationStrategy getImplementationStrategy(){
+		return strategy;
+	}
+	
+		
+	public String getPackageName() {
+		return packageName;
+	}
+	
+	
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.DAOProvider#getDAO(java.lang.String)
+	 */
+	@Override
+	public JpaDao getDAO(String daoClassname) {
+		LogManager.getLogger().info("Building DAO using classname:"+daoClassname);
+		return createDaoByClassname(daoClassname, null, null);
+	}
+	
+	
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.DaoProvider#getDAO(java.lang.String, kanad.kore.data.dao.JpaDao)
+	 */
+	@Override
+	public JpaDao getDAO(String daoClassname, JpaDao existingDAO) {
+		LogManager.getLogger().info("Building DAO using classname:"+daoClassname+" & existing DAO: "+existingDAO);
+		return createDaoByClassname(daoClassname, existingDAO, null);
+	}
+	
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.String, java.lang.Class)
+	 */
+	@Override
+	public JpaDao getDAO(String daoClassname, Class<? extends KEntity> parameterizedClass) {
+		LogManager.getLogger().info("Building DAO using classname:"+daoClassname+" & parameterizedClass: "+parameterizedClass);
+		return createDaoByClassname(daoClassname, null, parameterizedClass);
+	}
+	
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.Class)
+	 */
+	@Override
+	public JpaDao getDAO(Class<? extends JpaDao> daoClass) {
+		LogManager.getLogger().info("Building DAO using class:"+daoClass);
+		return createDaoByClass(daoClass, null, null);
+	}
+	
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.Class, java.lang.Object)
+	 */
+	@Override
+	public JpaDao getDAO(Class<? extends JpaDao> daoClass, JpaDao existingDAO) {
+		LogManager.getLogger().info("Building DAO using class:"+daoClass+" & existing DAO: "+existingDAO);
+		return createDaoByClass(daoClass, existingDAO, null);
+	}
+	
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.Class, java.lang.Class)
+	 */
+	@Override
+	public JpaDao getDAO(Class<? extends JpaDao> daoClass, Class<? extends KEntity> parameterizedClass) {
+		LogManager.getLogger().info("Building DAO using class:"+daoClass+" & parameterizedClass: "+parameterizedClass);
+		return createDaoByClass(daoClass, null, parameterizedClass);
+	}
+
+	
+	@SuppressWarnings("unchecked")
+	private JpaDao createDaoByClassname(String daoClassname, JpaDao existingDAO, Class<? extends KEntity> parameterizedClass){
+		JpaDao dao = null;
+		try {
+			if(packageName != null){
+				//resolve classname w.r.t the base package name provided else use the fully qualified classname.
+				daoClassname = packageName+"."+daoClassname;
+			}
+			Class<? extends JpaDao> daoClass = (Class<? extends JpaDao>) Class.forName(daoClassname);
+			dao = createDaoByClass(daoClass, existingDAO, parameterizedClass);
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		}
+		return dao;
+	}
+	
+	
+	private JpaDao createDaoByClass(Class<? extends JpaDao> daoClass, JpaDao existingDAO, Class<? extends KEntity> parameterizedClass){
+		LogManager.getLogger().info("Returning the DAO for: "+daoClass.getName());
+		
+		JpaDao dao = null;
+		try {
+			if(parameterizedClass != null){
+				LogManager.getLogger().info("Creating DAO instance using parameterized constructor...");
+				Constructor<? extends JpaDao> constructor = daoClass.getConstructor(Class.class);
+				LogManager.getLogger().info("Parameterized constructor = "+constructor);
+				if(!constructor.isAccessible()){
+					constructor.setAccessible(true);
+				}
+				dao = constructor.newInstance(parameterizedClass);
+			}else{
+				dao = daoClass.newInstance();
+			}
+			
+			EntityManager entityManager = null;
+			if(strategy == DaoImplementationStrategy.PER_THREAD){
+				LogManager.getLogger().warn("Current strategy is: PER_THREAD: one Entity Manager instance across all DAOs in same thread.");
+				
+				if(threadLocalManagedContext.get() == null){
+					LogManager.getLogger().warn("No Thread Local Context available! Building new one...");
+					PerThreadManagedContext perThreadManagedContext = new PerThreadManagedContext();
+					entityManager = emf.createEntityManager();
+					perThreadManagedContext.setEntityManager(entityManager);
+					threadLocalManagedContext.set(perThreadManagedContext);
+				}else{
+					LogManager.getLogger().info("Leveraging existing Entity Manager from Managed Thread Local Context");
+					entityManager = threadLocalManagedContext.get().getEntityManager();
+				}
+				
+				int emCount = threadLocalManagedContext.get().getEntityManagerCount();
+				threadLocalManagedContext.get().setEntityManagerCount(++emCount);
+				LogManager.getLogger().info("Total Ref Count for Thread Local EM: "+emCount);
+			}else{
+				//per instance
+				if(existingDAO != null){
+					LogManager.getLogger().info("Current strategy is: PER_INSTANCE: Reusing existing DAO/Entity Manager...");
+					entityManager = existingDAO.get();
+				}else{
+					//No existing DAO passed and additionally, the strategy is per instance.
+					LogManager.getLogger().warn("No existing DAO received; Current strategy is: PER_INSTANCE; one Entity Manager instance per DAO.");
+					entityManager = emf.createEntityManager();
+				}
+			}
+			
+			dao.set(entityManager);
+			((AbstractJpaDao)dao).setJpaDaoProvider(this);
+		} catch (InstantiationException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (IllegalAccessException e) {
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (NoSuchMethodException e) {
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (SecurityException e) {
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (IllegalArgumentException e) {
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (InvocationTargetException e) {
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		}
+		
+		return dao;
+	}
+
+	protected void closeThreadLocalManagedEntityManager(){
+		LogManager.getLogger().info("Closing Thread Local Managed Entity Manager...");
+		int emCount = threadLocalManagedContext.get().getEntityManagerCount();
+		threadLocalManagedContext.get().setEntityManagerCount(--emCount);
+		LogManager.getLogger().info("Total Ref Count for Thread Local EM: "+emCount);
+		if(emCount == 0){
+			LogManager.getLogger().info("No more active refs to Thread Local Managed Entity Manager; Cleaning up Thread Local Managed Context");
+			EntityManager entityManager = threadLocalManagedContext.get().getEntityManager();
+			if(entityManager != null && entityManager.isOpen()){
+				entityManager.close();
+				entityManager = null;
+			}
+			threadLocalManagedContext.remove();
+		}
+	}
+
+	
+	public void close() {
+		if(emf.isOpen()){
+			LogManager.getLogger().info("Closing EntityManagerFactory...");
+			emf.close();
+		}
+	}
+	
+	/*
+	 * @SuppressWarnings("unchecked")
+	@Override
+	public JpaDao getDAO(String classname, JpaDao existingDAO) {
+		LogManager.getLogger().info("Returning a DAO...");
+		LogManager.getLogger().error("Current strategy in place: "+ strategy.name());
+		
+		JpaDao kanad.kore.data.dao = null;
+		if(packageName != null){
+			//resolve classname w.r.t the base package name provided else use the fully qualified classname.
+			classname = packageName+"."+classname;
+		}
+		
+		LogManager.getLogger().info("Returning the DAO for: "+classname);
+		try {
+			Class<? extends JpaDao> daoClass = (Class<? extends JpaDao>) Class.forName(classname);
+			kanad.kore.data.dao = daoClass.newInstance();
+			
+			EntityManager entityManager = null;
+			if(strategy == DaoImplementationStrategy.PER_THREAD){
+				LogManager.getLogger().warn("Current strategy is: PER_THREAD: one Entity Manager instance across all DAOs in same thread.");
+				
+				if(threadLocalManagedContext.get() == null){
+					LogManager.getLogger().warn("No Thread Local Context available! Building new one...");
+					PerThreadManagedContext perThreadManagedContext = new PerThreadManagedContext();
+					entityManager = emf.createEntityManager();
+					perThreadManagedContext.setEntityManager(entityManager);
+					threadLocalManagedContext.set(perThreadManagedContext);
+				}else{
+					LogManager.getLogger().info("Leveraging existing Entity Manager from Managed Thread Local Context");
+					entityManager = threadLocalManagedContext.get().getEntityManager();
+				}
+				
+				int emCount = threadLocalManagedContext.get().getEntityManagerCount();
+				threadLocalManagedContext.get().setEntityManagerCount(++emCount);
+				LogManager.getLogger().info("Total Ref Count for Thread Local EM: "+emCount);
+			}else{
+				//per instance
+				if(existingDAO != null){
+					LogManager.getLogger().info("Current strategy is: PER_INSTANCE: Reusing existing DAO/Entity Manager...");
+					entityManager = existingDAO.get();
+				}else{
+					//No existing DAO passed and additionally, the strategy is per instance.
+					LogManager.getLogger().warn("No existing DAO received; Current strategy is: PER_INSTANCE; one Entity Manager instance per DAO.");
+					entityManager = emf.createEntityManager();
+				}
+			}
+			
+			kanad.kore.data.dao.set(entityManager);
+			((AbstractJpaDao)kanad.kore.data.dao).setJpaDaoProvider(this);
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (InstantiationException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		} catch (IllegalAccessException e) {
+			LogManager.getLogger().error("Can't create DAO!");
+			LogManager.getLogger().error("Exception : "+e);
+		}
+		
+		return kanad.kore.data.dao;
+	}
+	 */
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/impl/DefaultJpaDaoImpl.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/impl/DefaultJpaDaoImpl.java
@@ -1,0 +1,231 @@
+package kanad.kore.data.dao.jpa.impl;
+
+import kanad.kore.data.dao.jpa.AbstractJpaDao;
+import kanad.kore.data.dao.jpa.DefaultJpaDao;
+import kanad.kore.data.entity.jpa.AbstractEntity;
+import kanad.kore.data.entity.jpa.KEntity;
+import kanad.kore.data.entity.jpa.Remark;
+import org.apache.logging.log4j.LogManager;
+
+import javax.persistence.NoResultException;
+import javax.persistence.Query;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class DefaultJpaDaoImpl<T extends KEntity> extends AbstractJpaDao implements DefaultJpaDao<T> {
+	private Class<T> clazz;
+	
+	public DefaultJpaDaoImpl() {
+
+	}
+	
+	public DefaultJpaDaoImpl(Class<T> clazz) {
+		this.clazz = clazz;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.DefaultJpaDao#getEntityById(long)
+	 */
+	@Override
+	public AbstractEntity getById(long id) {
+		AbstractEntity absEntity = null;
+		try {
+			absEntity = entityManager.find(AbstractEntity.class, id);
+			if (absEntity != null) {
+				LogManager.getLogger().info("abs entity retrieved Id : " + absEntity.getId());
+			}
+		} catch (IllegalArgumentException ie) {
+			LogManager.getLogger().error("specified id or class for find not valid", ie);
+		} catch (Exception e) {
+			LogManager.getLogger().error("Exception !", e);
+		}
+		return absEntity;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.DefaultJpaDao#getEntityBySecureId(java.lang.String)
+	 */
+	@Override
+	public AbstractEntity getBySecureId(String secureId) {
+		AbstractEntity absEntity = null;	
+		try {
+			absEntity = entityManager
+					.createQuery("from AbstractEntity where secureID.sekID = :secureID and deleted = :isDeleted",
+							AbstractEntity.class)
+					.setParameter("secureID", secureId).setParameter("isDeleted", 0).getSingleResult();
+		} catch (IllegalArgumentException ie) {
+			LogManager.getLogger().error("specified id or class for find not valid", ie);
+		} catch (NoResultException ne) {
+			LogManager.getLogger().info("No Records Found");
+		} catch (Exception e) {
+			LogManager.getLogger().error("Exception !", e);
+		}
+		return absEntity;
+	}
+	
+	
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.jpa.DefaultJpaDao#add(kanad.kore.data.entity.AbstractEntity)
+	 */
+	@Override
+	public void add(T entity) {
+		LogManager.getLogger().info("Adding a generic/abstract entity...");
+		if(!hasActiveTransaction()){
+			LogManager.getLogger().info("No Active Txn for now; Txn Active Status = "+hasActiveTransaction());
+			//This is a local/single DAO scoped transaction.
+			beginTransaction();
+			entityManager.persist(entity);
+			commitTransaction();
+			//Haa, finally could find a way! This is the real trick :|
+			//Because the SecureID instance is not managed i.e. not the in persistence context, so calling getSecureID
+			//on any AbstractEntity instance is futile - it would return null.
+			//The SecureID records are managed by native DB trigger.
+			//Refer: generating_secure_ids_for_the_entities_for_use_in_the_web_services in the docs or
+			//SupplementaryDAOImpl.createSecureIDTrigger()
+			//So, to force AbstractEntity instance to reconcile and load the related SecureID in the current persistent
+			//context, we call refresh. From this point onwards, SecureID becomes managed.
+			//Need to follow this pattern and start using secure ids in the web service request/response.
+			refresh(entity);
+		}else{
+			//This is multi DAO scope transaction.
+			LogManager.getLogger().info("Ongoing Active Txn; Txn Active Status = "+hasActiveTransaction());
+			entityManager.persist(entity);
+		}
+	}
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.jpa.DefaultJpaDao#addAll(java.util.Collection)
+	 */
+	@Override
+	public void addAll(Collection<T> entities) {
+		LogManager.getLogger().info("Adding all generic/abstract entities...");
+		if(!hasActiveTransaction()){
+			beginTransaction();
+			for(T entity: entities){
+				add(entity);
+			}
+			commitTransaction();
+		}else{
+			for(T entity: entities){
+				add(entity);
+			}
+		}
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.jpa.DefaultJpaDao#update(kanad.kore.data.entity.AbstractEntity)
+	 */
+	@Override
+	public T update(T entity) {
+		LogManager.getLogger().info("Updating a generic/abstract entity...");
+		T mergedEntity = null;
+		
+		if(!hasActiveTransaction()){
+			beginTransaction();
+			mergedEntity = entityManager.merge(entity);
+			commitTransaction(); 
+			refresh(mergedEntity);
+		}else{
+			mergedEntity = entityManager.merge(entity);
+		}
+		
+		return mergedEntity;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.jpa.DefaultJpaDao#delete(kanad.kore.data.entity.AbstractEntity)
+	 */
+	@Override
+	public void delete(T entity) {
+		//Soft delete
+		if(entity instanceof AbstractEntity){
+			((AbstractEntity)entity).setDeleted(1);
+		}
+		
+		if(!hasActiveTransaction()){
+			beginTransaction();	
+			entityManager.merge(entity);
+			commitTransaction(); 
+		}else{
+			entityManager.merge(entity);
+		}
+	}
+	
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.jpa.DefaultJpaDao#deleteHard(kanad.kore.data.entity.AbstractEntity)
+	 */
+	@Override
+	public void deleteHard(T entity) {
+		if(!hasActiveTransaction()){
+			beginTransaction();	
+			entityManager.remove(entity);
+			commitTransaction(); 
+		}else{
+			entityManager.remove(entity);
+		}
+		
+	}
+
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.jpa.DefaultJpaDao#deleteAll(java.lang.boolean)
+	 */
+	@Override
+	public void deleteAll(boolean hardDelete) {
+		LogManager.getLogger().info("Deleting all generic/abstract entities...");
+		
+		Query query = null;
+		if(hardDelete){
+			query = entityManager.createQuery("delete from "+clazz.getSimpleName());
+		}else{
+			query = entityManager.createQuery("update "+clazz.getSimpleName()+" set deleted = 1");
+		}
+		
+		if(!hasActiveTransaction()){
+			beginTransaction();
+			query.executeUpdate();
+			commitTransaction();
+		}else{
+			query.executeUpdate();
+		}
+	}
+
+	
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.jpa.DefaultJpaDao#getAll()
+	 */
+	@Override
+	public List<T> getAll(int orgId) {
+		//unsupported: subclasses shall have their specific implementation.
+		LogManager.getLogger(this.getClass().getName()).info("Returning entity list...");
+		
+		List<T> list = new ArrayList<>();
+		try {
+			list = entityManager.createQuery(
+					"from "+clazz.getSimpleName()+
+					" where deleted = :isDeleted and orgId = :orgId ORDER BY updatedOn DESC",
+					clazz)
+					.setParameter("isDeleted", 0)
+					.setParameter("orgId", orgId)
+					.getResultList();
+		} catch (NoResultException ne) {
+			LogManager.getLogger(this.getClass().getName()).info("No records found");
+		}
+		return list;
+	}
+	
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.DefaultJpaDao#addRemark(kanad.kore.data.entity.jpa.Remark)
+	 */
+	@Override
+	public void addRemark(Remark remark){
+		LogManager.getLogger().info("Adding remark...");
+		beginTransaction();
+		entityManager.persist(remark);
+		commitTransaction();
+		refresh(remark);
+		LogManager.getLogger().info("Done persisting remarks!");
+	}
+	
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/jpa/impl/SupplementaryDAOImpl.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/jpa/impl/SupplementaryDAOImpl.java
@@ -1,0 +1,63 @@
+package kanad.kore.data.dao.jpa.impl;
+
+import kanad.kore.data.entity.jpa.AbstractEntity;
+import org.apache.logging.log4j.LogManager;
+
+import javax.persistence.Query;
+
+public class SupplementaryDAOImpl extends DefaultJpaDaoImpl<AbstractEntity> {
+	private static final String SEC_ID_GEN_TRIGGER = "sec_id_gen_trigger";
+	//name of the table on which the above trigger is created.
+	private static final String TABLE_NAME = "AbstractEntity";
+	
+	public SupplementaryDAOImpl() {
+		this(AbstractEntity.class);
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * @param clazz
+	 */
+	public SupplementaryDAOImpl(Class<AbstractEntity> clazz) {
+		super(clazz);
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * If the trigger already exists, then it's a no-op else it creates a new sec id generation trigger.
+	 */
+	public void createSecureIDTrigger(){
+		if(secureIDTriggerExists()){
+			LogManager.getLogger().info(SEC_ID_GEN_TRIGGER+"exists! Nothing to do.");
+			return;
+		}
+		
+		String triggerSQL =
+				"CREATE TRIGGER "+ SEC_ID_GEN_TRIGGER +" AFTER INSERT ON AbstractEntity "
+				+ "FOR EACH ROW "
+				+ "INSERT INTO SecureID(entityId, sekId) VALUES(NEW.id, sha2(CONCAT(NEW.discType,'_',NEW.id),256))";
+		Query query =  entityManager.createNativeQuery(triggerSQL);
+		try{
+			beginTransaction();
+			int status = query.executeUpdate();
+			commitTransaction();
+			LogManager.getLogger().info("CreateSecureIDTrigger status = "+status);
+		}catch(Exception e){
+			LogManager.getLogger().error("CreateSecureIDTrigger failed- unable to commit transaction");
+			LogManager.getLogger().error("Exception: "+e);
+			LogManager.getLogger().error("Rolling back..");
+			rollbackTransaction();
+			LogManager.getLogger().error("Done!");
+		}
+	}
+	
+	
+	private boolean secureIDTriggerExists(){
+		LogManager.getLogger().info("Checking if "+SEC_ID_GEN_TRIGGER+" exists...");
+		//Show triggers on Entity table
+		String triggerSQL =  "SHOW TRIGGERS LIKE '"+ TABLE_NAME+ "'";
+		Query query =  entityManager.createNativeQuery(triggerSQL);
+		//Only 1 trigger currently, so this check will suffice for now.
+		return query.getResultList().size() == 1;
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/raw/AbstractRawDao.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/raw/AbstractRawDao.java
@@ -1,0 +1,159 @@
+package kanad.kore.data.dao.raw;
+
+import org.apache.logging.log4j.LogManager;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class AbstractRawDao implements RawDao {
+	protected Connection connection;
+	private boolean txnInProgress;
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#set(java.lang.Object)
+	 */
+	@Override
+	public void set(Connection connection) {
+		this.connection = connection;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#get()
+	 */
+	@Override
+	public Connection get() {
+		return connection;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#close()
+	 */
+	@Override
+	public void close() {
+		try {
+			connection.close();
+		} catch (SQLException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Not able to close JDBC connection: "+connection);
+			LogManager.getLogger().error("Exception : "+e);
+		}finally{
+			connection = null;
+		}
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#beginTransaction()
+	 * If underlying connection's auto commit mode is set to true, then this method is a no-op.
+	 * @see java.sql.Connection for more details.
+	 */
+	@Override
+	public void beginTransaction() {
+		try{
+			if(!connection.getAutoCommit()){
+				txnInProgress = true;
+			}
+		}catch (SQLException e) {
+			e.printStackTrace();
+			txnInProgress = false;
+			LogManager.getLogger().error("Can't being transaction on connection: "+connection);
+			LogManager.getLogger().error("Exception : "+e);
+		}
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#commitTransaction()
+	 * If underlying connection's auto commit mode is set to true, then this method is a no-op.
+	 * @see java.sql.Connection for more details.
+	 */
+	@Override
+	public void commitTransaction() {
+		try{
+			if(!isAutoCommit()){
+				connection.commit();
+			}
+		}catch (SQLException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't commit ongoing transaction on connection: "+connection);
+			LogManager.getLogger().error("Exception : "+e);
+			LogManager.getLogger().error("Rolling back ongoing transaction... ");
+			rollbackTransaction();
+		}finally{
+			txnInProgress = false;
+		}
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#rollbackTransaction()
+	 * If underlying connection's auto commit mode is set to true, then this method is a no-op.
+	 * @see java.sql.Connection for more details.
+	 */
+	@Override
+	public void rollbackTransaction() {
+		try{
+			if(!isAutoCommit()){
+				connection.rollback();
+			}
+		}catch (SQLException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't rollback ongoing transaction on connection: "+connection);
+			LogManager.getLogger().error("Exception : "+e);
+		}finally{
+			txnInProgress = false;
+		}
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#hasActiveTransaction()
+	 * If underlying connection's auto commit mode is set to true, then this method is irrelevant and will always return false.
+	 * @see java.sql.Connection for more details.
+	 */
+	@Override
+	public boolean hasActiveTransaction() {
+		return txnInProgress;
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#setAutoCommit(boolean)
+	 * If underlying connection's auto commit mode was off before calling this method and if the mode is requested to be turned on, then this method will
+	 * first commit the changes pending for the ongoing transaction and subsequent call to hasActiveTransaction() will return false.
+	 * If the requested mode and existing mode are unchanged, this method is no-op.
+	 * @see java.sql.Connection#setAutoCommit for more details.
+	 */
+	@Override
+	public void setAutoCommit(boolean autoCommit) {
+		try {
+			if(isAutoCommit() == autoCommit){
+				//no-op
+				return;
+			}
+			//connection was not in autocommit mode earlier and now turning it on
+			if(!isAutoCommit() && hasActiveTransaction()){
+				//Make sure you commit ongoing transaction 1st
+				LogManager.getLogger().warn("Reuest to enable auto-commit mode;commiting ongoing transaction first...");
+				commitTransaction();
+			}
+			connection.setAutoCommit(autoCommit);
+		} catch (SQLException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Can't change auto commit mode on underlying JDBC connection: "+connection);
+			LogManager.getLogger().error("Exception : "+e);
+		}
+	}
+
+	/* (non-Javadoc)
+	 * kanad.kore.data.dao.Dao#getAutoCommit()
+	 */
+	@Override
+	public boolean isAutoCommit() {
+		boolean autoCommit = false;
+		try {
+			autoCommit = connection.getAutoCommit();
+		} catch (SQLException e) {
+			e.printStackTrace();
+			LogManager.getLogger().error("Unable to get auto commit mode on underlying JDBC connection: "+connection);
+			LogManager.getLogger().error("Exception : "+e);
+		}
+		return autoCommit;
+	}
+
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/raw/RawDao.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/raw/RawDao.java
@@ -1,0 +1,9 @@
+package kanad.kore.data.dao.raw;
+
+import kanad.kore.data.dao.Dao;
+
+import java.sql.Connection;
+
+public interface RawDao extends Dao<Connection> {
+	
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/raw/RawDaoProvider.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/raw/RawDaoProvider.java
@@ -1,0 +1,10 @@
+package kanad.kore.data.dao.raw;
+
+import kanad.kore.data.dao.DaoProvider;
+
+public interface RawDaoProvider<T> extends DaoProvider<RawDao, T> {
+	public static final String CONN_URL="conn.url";
+	public static final String CONN_USERNAME="conn.username";
+	public static final String CONN_PASSWORD="conn.password";
+	public static final String CONN_DRIVER="conn.driver";
+}

--- a/kore-data/src/main/java/kanad/kore/data/dao/raw/RawDaoProviderImpl.java
+++ b/kore-data/src/main/java/kanad/kore/data/dao/raw/RawDaoProviderImpl.java
@@ -1,0 +1,178 @@
+package kanad.kore.data.dao.raw;
+
+
+import kanad.kore.data.dao.DaoProviderFactory.DaoImplementationStrategy;
+
+import java.util.Properties;
+
+//TODO: Provide one more variant for DataSource based connection pool compliant JDBC connection management or
+// accommodate it in the same class.
+//Refer:
+//c3p0
+//http://www.mchange.com/projects/c3p0
+//https://github.com/swaldman/c3p0
+//Apache DBCP
+//http://commons.apache.org/proper/commons-dbcp/
+
+public class RawDaoProviderImpl implements RawDaoProvider {
+	//DAO base package name
+	private String packageName;
+	private Properties connProperties;
+	private boolean open;
+	private DaoImplementationStrategy strategy;
+	
+	
+	public RawDaoProviderImpl(String packageName, Properties connProperties) {
+		this(packageName, connProperties, DaoImplementationStrategy.PER_INSTANCE);
+	}
+	
+	
+	public RawDaoProviderImpl(String packageName, Properties connProperties, DaoImplementationStrategy strategy) {
+		this.packageName = packageName;
+		this.connProperties = connProperties;
+		this.strategy = strategy;
+		open = true;
+	}
+	
+	
+	public DaoImplementationStrategy getImplementationStrategy(){
+		return strategy;
+	}
+	
+	
+//	@Override
+//	public RawDao getDAO(String classname) {
+//		return getDAO(classname, null);
+//	}
+//	
+//	
+//	/* (non-Javadoc)
+//	 * kanad.kore.data.dao.DaoProvider#getDAO(java.lang.String, kanad.kore.data.dao.Dao)
+//	 */
+//	@SuppressWarnings("unchecked")
+//	@Override
+//	public RawDao getDAO(String classname, RawDao existingDAO) {
+//		RawDao kanad.kore.data.dao = null;
+//		if(!isOpen()){
+//			return null;
+//		}
+//		
+//		if(packageName != null){
+//			//resolve classname w.r.t the base package name provided else use the fully qualified classname.
+//			classname = packageName+"."+classname;
+//		}
+//		LogManager.getLogger().info("Returning the DAO for: "+classname);
+//		
+//		try {
+//			Class<? extends RawDao> daoClass = (Class<? extends RawDao>) Class.forName(classname);
+//			kanad.kore.data.dao = daoClass.newInstance();
+//			
+//			if(existingDAO != null){
+//				LogManager.getLogger().info("Reusing existing DAO/Connection...");
+//				kanad.kore.data.dao.set(((RawDao)existingDAO).get());
+//			}else{
+//				if(strategy == DaoImplementationStrategy.PER_THREAD){
+//					LogManager.getLogger().warn("Current strategy is: PER_THREAD, creating a new Connection per DAO is same as PER_INSTANCE; make sure you pass existing DAO to achieve the expected behavior!");
+//				}
+//				Connection conn = DriverManager.getConnection(connProperties.getProperty(CONN_URL), connProperties.getProperty(CONN_USERNAME), connProperties.getProperty(CONN_PASSWORD));
+//				kanad.kore.data.dao.set(conn);
+//			}
+//		} catch (ClassNotFoundException e) {
+//			e.printStackTrace();
+//			LogManager.getLogger().error("Can't create DAO!");
+//			LogManager.getLogger().error("Exception : "+e);
+//		} catch (InstantiationException e) {
+//			e.printStackTrace();
+//			LogManager.getLogger().error("Can't create DAO!");
+//			LogManager.getLogger().error("Exception : "+e);
+//		} catch (IllegalAccessException e) {
+//			e.printStackTrace();
+//			LogManager.getLogger().error("Can't create DAO!");
+//			LogManager.getLogger().error("Exception : "+e);
+//		} catch (SQLException e) {
+//			e.printStackTrace();
+//			LogManager.getLogger().error("Can't create DAO: not able to create a JDBC connection!");
+//			LogManager.getLogger().error("Exception : "+e);
+//		}
+//		
+//		return kanad.kore.data.dao;
+//	}
+
+	
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.String)
+	 */
+	@Override
+	public Object getDAO(String daoClassname) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.String, java.lang.Object)
+	 */
+	@Override
+	public Object getDAO(String daoClassname, Object existingDAO) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.String, java.lang.Class)
+	 */
+	@Override
+	public Object getDAO(String daoClassname, Class parameterizedClassname) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.Class)
+	 */
+	@Override
+	public Object getDAO(Class daoClass) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.Class, java.lang.Object)
+	 */
+	@Override
+	public Object getDAO(Class daoClass, Object existingDAO) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	/* (non-Javadoc)
+	 * @see kanad.kore.data.dao.DaoProvider#getDAO(java.lang.Class, java.lang.Class)
+	 */
+	@Override
+	public Object getDAO(Class daoClass, Class parameterizedClassname) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	@Override
+	public String getPackageName() {
+		return packageName;
+	}
+	
+	public boolean isOpen(){
+		return open;
+	}
+
+	@Override
+	public void close() {
+		if(isOpen()){
+			open = false;
+		}
+	}
+
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/AbstractAssoc.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/AbstractAssoc.java
@@ -1,0 +1,44 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+
+@MappedSuperclass
+//Let it inherit from AbstractEntity; that way even events/ops can be
+//associated with remarks as well.
+public class AbstractAssoc extends AbstractEntity {
+	
+	@Temporal(TemporalType.TIMESTAMP)
+	private Date startDate;
+	
+	@Temporal(TemporalType.TIMESTAMP)
+	private Date endDate;
+	
+	public AbstractAssoc() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	public Date getEndDate() {
+		return endDate;
+	}
+
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+
+	@Override
+	public String toString() {
+		return "AbstractAssoc [startDate=" + startDate + ", endDate=" + endDate + "]";
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/AbstractEntity.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/AbstractEntity.java
@@ -1,0 +1,153 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.*;
+import java.util.Collection;
+import java.util.Date;
+
+
+@Entity
+@Inheritance(strategy=InheritanceType.JOINED)
+@DiscriminatorColumn(name="discType")
+public abstract class AbstractEntity implements KEntity {
+	/*
+	 * Was AUTO earlier - hibernate uses TABLE gen strategy which is to simulate
+	 * sequence using database table. Generally, hibernate creates
+	 * hibernate_sequence table to simulates the sequence. But it has a
+	 * performance bottleneck in that - it holds the row level lock on this
+	 * table to get next_val. Row level lock is needed to make sure that no 2
+	 * concurrent transactions are able to retrieve the next possible value at
+	 * once to prevent dirty reads. Culprit is: select from .. update which holds
+	 * the row level lock as evident from the following observation.
+	 * Here's a sample o/p of: SHOW ENGINE INNODB STATUS\G
+	 * query when tested the parking-discovery module/microservice with 50 concurrent requests:
+	 * 
+	 * ---TRANSACTION 123057, ACTIVE 45 sec
+	 * starting index read mysql tables in use 1, locked 1 LOCK WAIT 2 lock
+	 * struct(s), heap size 1136, 1 row lock(s) MySQL thread id 94, OS thread
+	 * handle 140393856878336, query id 211701 localhost 127.0.0.1 psadmin
+	 * Sending data select next_val as id_val from hibernate_sequence for update
+	 * ------- TRX HAS BEEN WAITING 45 SEC FOR THIS LOCK TO BE GRANTED: RECORD
+	 * LOCKS space id 1868 page no 3 n bits 72 index GEN_CLUST_INDEX of table
+	 * `psmgmt`.`hibernate_sequence` trx id 123057 lock_mode X locks rec but
+	 * not gap waiting Record lock, heap no 2 PHYSICAL RECORD: n_fields 4;
+	 * compact format; info bits 0 0: len 6; hex 000000000c02; asc ;; 1: len 6;
+	 * hex 00000001e086; asc ;; 2: len 7; hex 7100000232057a; asc q 2 z;; 3: len
+	 * 8; hex 80000000000005c0; asc ;;
+	 * 
+	 * ------------------
+	 */
+	@Id
+	@GeneratedValue(strategy=GenerationType.IDENTITY)
+	private long id;
+	
+	@OneToOne(mappedBy="entity", fetch=FetchType.EAGER)
+	private SecureID secureID;
+	
+	@Temporal(TemporalType.TIMESTAMP)
+	@Column(nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private Date createdOn;
+
+	@Column(nullable = true)
+	private String createdBy;
+	
+	//Make sure you have mysql 5.7+ if default value needs to be CURRENT_TIMESTAMP; older versions don't allow
+	//2 columns in same table to have CURRENT_TIMESTAMP as default value
+	@Temporal(TemporalType.TIMESTAMP)
+	//@Column(columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+	@Column(columnDefinition = "TIMESTAMP null")
+    private Date updatedOn = new Date();
+
+    @Column(nullable = true)
+	private String updatedBy;
+	
+    @Column(nullable = false, columnDefinition="TINYINT DEFAULT 0")
+    private int deleted;
+    
+    @Column(nullable = false)
+    private int orgId;
+    
+    @OneToMany(mappedBy="owner", fetch=FetchType.LAZY)
+	private Collection<Remark> remarks;
+    
+    public AbstractEntity(){
+    	
+    }
+    
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+	
+	public SecureID getSecureID() {
+		return secureID;
+	}
+	
+	/**
+	 * 
+	 * @param secureID
+	 * This method shall only be used while merging an existing entity into an updated one.
+	 * In such a scenario, one shall set secure id on the updated one and merge.
+	 */
+	public void setSecureID(SecureID secureID) {
+		this.secureID = secureID;
+	}
+
+	public String getCreatedBy() {
+		return createdBy;
+	}
+
+	public void setCreatedBy(String createdBy) {
+		this.createdBy = createdBy;
+	}
+
+	public String getUpdatedBy() {
+		return updatedBy;
+	}
+
+	public void setUpdatedBy(String updatedBy) {
+		this.updatedBy = updatedBy;
+	}
+
+	public int isDeleted() {
+		return deleted;
+	}
+
+	public void setDeleted(int deleted) {
+		this.deleted = deleted;
+	}
+
+	public int getOrgId() {
+		return orgId;
+	}
+
+	public void setOrgId(int orgId) {
+		this.orgId = orgId;
+	}
+
+	public Collection<Remark> getRemarks() {
+		return remarks;
+	}
+
+	public void setRemarks(Collection<Remark> remarks) {
+		this.remarks = remarks;
+	}
+
+	public Date getCreatedOn() {
+		return createdOn;
+	}
+
+	public void setCreatedOn(Date createdOn) {
+		this.createdOn = createdOn;
+	}
+
+	public Date getUpdatedOn() {
+		return updatedOn;
+	}
+
+	public void setUpdatedOn(Date updatedOn) {
+		this.updatedOn = updatedOn;
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/Address.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/Address.java
@@ -1,0 +1,131 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.*;
+
+@Entity
+public class Address extends AbstractEntity {
+	private String addressLine1;
+	private String addressLine2;
+	private String city;
+	private String state;
+	private String pin;
+	private String purpose;
+	@Enumerated(EnumType.STRING)
+	private AddressType addressType;  //ENUM
+	
+	@ManyToOne(fetch=FetchType.LAZY)
+	@JoinColumn(name = "partyId", referencedColumnName = "id", nullable = false)
+	private AbstractEntity party;
+
+	public enum AddressType {
+		PERMANENT("Permanent"),
+		PRESENT("Present");
+		
+		private String textValue;
+		
+		private AddressType(String textValue) {
+			this.textValue = textValue;
+		}
+
+		/**
+		 * @return the textValue
+		 */
+		public String getTextValue() {
+			return textValue;
+		}
+
+		/* (non-Javadoc)
+		 * @see java.lang.Enum#toString()
+		 */
+		@Override
+		public String toString() {
+			// TODO Auto-generated method stub
+			return getTextValue(); 
+		}
+		
+		//enum from text value field
+		public static AddressType fromTextValue(String tv){
+			if(tv.equals("Permanent")){
+				return AddressType.PERMANENT;
+			}
+			return AddressType.PRESENT;
+		}
+		
+		//text value field from enum value string
+		public static String fromEnumValue(String value){
+			if(value.equals("PERMANENT")){
+				return "Permanent";
+			}
+			return "Present";
+		}
+	}
+	
+	public Address() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public String getAddressLine1() {
+		return addressLine1;
+	}
+
+	public void setAddressLine1(String addressLine1) {
+		this.addressLine1 = addressLine1;
+	}
+
+	public String getAddressLine2() {
+		return addressLine2;
+	}
+
+	public void setAddressLine2(String addressLine2) {
+		this.addressLine2 = addressLine2;
+	}
+
+	public String getCity() {
+		return city;
+	}
+
+	public void setCity(String city) {
+		this.city = city;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	public String getPin() {
+		return pin;
+	}
+
+	public void setPin(String pin) {
+		this.pin = pin;
+	}
+
+	public String getPurpose() {
+		return purpose;
+	}
+
+	public void setPurpose(String purpose) {
+		this.purpose = purpose;
+	}
+
+	public AddressType getAddressType() {
+		return addressType;
+	}
+
+	public void setAddressType(AddressType addressType) {
+		this.addressType = addressType;
+	}	
+	
+	public AbstractEntity getParty() {
+		return party;
+	}
+
+	public void setParty(AbstractEntity party) {
+		this.party = party;
+	}
+	
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/KEntity.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/KEntity.java
@@ -1,0 +1,5 @@
+package kanad.kore.data.entity.jpa;
+
+public interface KEntity {
+
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/Label.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/Label.java
@@ -1,0 +1,72 @@
+package kanad.kore.data.entity.jpa;
+
+public class Label {
+	/**
+	 * The type is typically a simple class name (sans fully qualified package name) of the owner entity to which the
+	 * property identified by 'name' belongs.
+	 */
+	private String type;
+	/**
+	 * name is the field/property name on the current label type.
+	 */
+	private String name;
+	/**
+	 * value is the actual value for the property/field identified by 'name' on current label type.
+	 */
+	private String value;
+	
+	/**
+	 * The Secure ID of the owner entity of type 'type'.
+	 * This will be typically needed while navigating to the corresponding owner entity/resource.
+	 */
+	private String id;
+	
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
+	}
+	/**
+	 * @return the value
+	 */
+	public String getValue() {
+		return value;
+	}
+	/**
+	 * @param value the value to set
+	 */
+	public void setValue(String value) {
+		this.value = value;
+	}
+	/**
+	 * @return the name
+	 */
+	public String getName() {
+		return name;
+	}
+	/**
+	 * @param name the name to set
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+	/**
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
+	/**
+	 * @param id the id to set
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/Party.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/Party.java
@@ -1,0 +1,55 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.*;
+import java.util.Collection;
+
+@MappedSuperclass
+public class Party extends AbstractEntity {
+	
+	protected String name;
+	
+	@OneToMany(mappedBy="party", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch=FetchType.LAZY)
+	protected Collection<Address> addresses;
+	
+	protected String emailId;
+	
+	@Embedded
+	protected Phone phone;
+	
+	public Party() {
+		// TODO Auto-generated constructor stub
+	}
+	
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Collection<Address> getAddresses() {
+		return addresses;
+	}
+
+	public void setAddresses(Collection<Address> addresses) {
+		this.addresses = addresses;
+	}
+
+	public Phone getPhone() {
+		return phone;
+	}
+
+	public void setPhone(Phone phone) {
+		this.phone = phone;
+	}
+	
+	public String getEmailId() {
+		return emailId;
+	}
+
+	public void setEmailId(String emailId) {
+		this.emailId = emailId;
+	}
+
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/Phone.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/Phone.java
@@ -1,0 +1,94 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class Phone {
+	//primary
+	private String mobile1;
+	//secondary.
+	private String mobile2;
+	private String emergencyContact1MobNo;
+	private String emergencyContactName1;
+	private String relationWithEmergencyContact1; 
+	private String emergencyContact2MobNo;
+	private String emergencyContactName2;
+	private String relationWithEmergencyContact2; 
+	private String landline;
+	
+	public Phone() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public String getMobile1() {
+		return mobile1;
+	}
+
+	public void setMobile1(String mobile1) {
+		this.mobile1 = mobile1;
+	}
+
+	public String getMobile2() {
+		return mobile2;
+	}
+
+	public void setMobile2(String mobile2) {
+		this.mobile2 = mobile2;
+	}
+
+	public String getEmergencyContact1MobNo() {
+		return emergencyContact1MobNo;
+	}
+
+	public void setEmergencyContact1MobNo(String emergencyContact1MobNo) {
+		this.emergencyContact1MobNo = emergencyContact1MobNo;
+	}
+
+	public String getEmergencyContactName1() {
+		return emergencyContactName1;
+	}
+
+	public void setEmergencyContactName1(String emergencyContactName1) {
+		this.emergencyContactName1 = emergencyContactName1;
+	}
+
+	public String getRelationWithEmergencyContact1() {
+		return relationWithEmergencyContact1;
+	}
+
+	public void setRelationWithEmergencyContact1(String relationWithEmergencyContact1) {
+		this.relationWithEmergencyContact1 = relationWithEmergencyContact1;
+	}
+
+	public String getEmergencyContact2MobNo() {
+		return emergencyContact2MobNo;
+	}
+
+	public void setEmergencyContact2MobNo(String emergencyContact2MobNo) {
+		this.emergencyContact2MobNo = emergencyContact2MobNo;
+	}
+
+	public String getEmergencyContactName2() {
+		return emergencyContactName2;
+	}
+
+	public void setEmergencyContactName2(String emergencyContactName2) {
+		this.emergencyContactName2 = emergencyContactName2;
+	}
+
+	public String getRelationWithEmergencyContact2() {
+		return relationWithEmergencyContact2;
+	}
+
+	public void setRelationWithEmergencyContact2(String relationWithEmergencyContact2) {
+		this.relationWithEmergencyContact2 = relationWithEmergencyContact2;
+	}
+
+	public String getLandline() {
+		return landline;
+	}
+
+	public void setLandline(String landline) {
+		this.landline = landline;
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/Remark.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/Remark.java
@@ -1,0 +1,134 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+
+@Entity
+public class Remark extends AbstractEntity{
+	//maintain the history of remarks for an entity/event/operation.
+	@ManyToOne(fetch=FetchType.LAZY)
+	@JoinColumn(name="ownerId", referencedColumnName="id")
+	private AbstractEntity owner;
+	
+	//comma separated tuples.
+	//making text coz column may need substantial space depending on the number of labels defined for the entity.
+	@Column(columnDefinition="TEXT")
+	private String labels;
+	
+	@Transient
+	private List<Label> labelList;
+	
+	private String value;
+
+	public Remark() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public AbstractEntity getOwner() {
+		return owner;
+	}
+
+	public void setOwner(AbstractEntity owner) {
+		this.owner = owner;
+	}
+	
+	
+	/**
+	 * @return the labels
+	 */
+	public String getLabels() {
+		return labels;
+	}
+
+	/**
+	 * @param labels the labels to set
+	 */
+	public void setLabels(String labels) {
+		this.labels = labels;
+	}
+	
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	/**
+	 * 
+	 * @return the List of labels constructed from the current labels string.
+	 * Note that this label list is constructed by scanning the labels string and this is done only once in the lifetime of the Remark object.
+	 * Once constructed, subsequent calls to this method will retrun this pre-generated/cached labels list.
+	 * This means once constructed, number of labels on the remark remain unchanged, though their attributes might change.
+	 */
+	public List<Label> getLabelsAsList() {
+		if(labelList != null){
+			return labelList;
+		}
+		
+		labelList = new ArrayList<>();
+		if(labels.contains(",")){
+			String[] labelArray = labels.split(",");
+			for(String label : labelArray){
+				labelList.add(buildLabel(label));
+			}
+		}else if(labels.contains(";")){
+			labelList.add(buildLabel(labels));
+		}
+			
+		return labelList;
+	}
+
+	/**
+	 * 
+	 * @param labels the list of labels for this remark.
+	 * This method processes the given label list and updates the labels string corresponding to this remark.
+	 * Note that ultimately, it's the labels string that will be persisted to the DB.
+	 * List<Label> is a handy and more organized way to refer to the remark labels in the code. 
+	 */
+	public void setLabelsAsList(List<Label> labels) {
+		if(labels == null){
+			//This means just rebuild the labels string from the updated list contents
+			labels = this.labelList;
+		}
+		
+		StringBuffer labelsCSV = new StringBuffer();
+		for(Iterator<Label> iterator = labels.iterator(); iterator.hasNext();){
+			Label label = iterator.next();
+			labelsCSV.append(label.getType());
+			labelsCSV.append(";");
+			labelsCSV.append(label.getName());
+			labelsCSV.append(";");
+			labelsCSV.append(label.getValue());
+			labelsCSV.append(";");
+			labelsCSV.append(label.getId());
+			labelsCSV.append(",");
+		}
+		labelsCSV.deleteCharAt(labelsCSV.length()-1);//remove last comma
+		this.labels = labelsCSV.toString();
+	}
+	
+	
+	public void refreshLabelsString(){
+		setLabelsAsList(null);
+	}
+
+	//Helpers
+	private Label buildLabel(String labelString){
+		Label label = new Label();
+		if(labelString.contains(";")){
+			String[] parts = labelString.split(";");
+			if(parts.length == 4){
+				label.setType(parts[0]);
+				label.setName(parts[1]);
+				label.setValue(parts[2]);
+				label.setId(parts[3]);
+			}
+		}
+		return label;
+	}
+}

--- a/kore-data/src/main/java/kanad/kore/data/entity/jpa/SecureID.java
+++ b/kore-data/src/main/java/kanad/kore/data/entity/jpa/SecureID.java
@@ -1,0 +1,59 @@
+package kanad.kore.data.entity.jpa;
+
+import javax.persistence.*;
+
+@Entity
+/**
+ * Refer: generating_secure_ids_for_the_entities_for_use_in_the_web_services or
+ * SupplementaryDAOImpl.createSecureIDTrigger() for more details.
+ * All the setters methods shall only be used while merging the owning entity of this secure id instance.
+ */
+public class SecureID implements KEntity {
+	@Id
+	@GeneratedValue(strategy=GenerationType.IDENTITY)
+	private long id;
+	
+	@OneToOne(fetch=FetchType.LAZY)
+	@JoinColumn(name="entityId", referencedColumnName="id")
+	private AbstractEntity entity;
+	
+	@Column(columnDefinition="varchar(256)")
+	private String sekId;
+	
+	
+	/**
+	 * @return the id
+	 */
+	public long getId() {
+		return id;
+	}
+
+	/**
+	 * @param id the id to set
+	 */
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	/**
+	 * @return the entity
+	 */
+	public AbstractEntity getEntity() {
+		return entity;
+	}
+
+	/**
+	 * @param entity the entity to set
+	 */
+	public void setEntity(AbstractEntity entity) {
+		this.entity = entity;
+	}
+
+	public String getSekId() {
+		return sekId;
+	}
+	
+	public void setSekId(String sekId) {
+		this.sekId = sekId;
+	}
+}

--- a/kore-data/src/test/java/kanad/kore/data/AppTest.java
+++ b/kore-data/src/test/java/kanad/kore/data/AppTest.java
@@ -1,0 +1,38 @@
+package kanad.kore.data;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
adds the core data framework that abstracts:
1. data access objects (`DAO`s)
2. provide `DAO` capabilities for both `JPA` based and raw `JDBC` based data access
3. follows multi table inheritance for `JPA` entities with `AbstractEntity` at the root of the inheritance hierarchy.
4. also adds few entities like - `Party, Phone, Address` that are quite common to any business/domain/enterprise.